### PR TITLE
Common server role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# ansible-common-server
+Common Server
+=============
+
+A role that sets up a generic server with some base configuration, in in itself it. 
+
+By default it configures UFW to deny all incoming traffic except ssh, add own rules so 
+your services are visible :)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+COMMON_SERVER_HOSTNAME: "{{ inventory_hostname }}"
+COMMON_SERVER_HOSTNAME_SHORT: "{{ inventory_hostname_short }}"
+
+COMMON_SERVER_ETCKEEPER_COMMIT_USER: "Etc Keeper"
+COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: "ops@example.com"
+
+# Please think twice before setting it
+COMMON_SERVER_NO_BACKUPS: false
+
+COMMON_SERVER_DEPENDENCIES:
+  - etckeeper
+  - tmpreaper

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,8 @@
+dependencies:
+  - name: configure-apt
+  - name: geerlingguy.security
+  - name: sanity-checker
+  - name: kamaln7.swapfile
+  # Will fail provisioning if settings not set in vars file.
+  - name: backup-to-tarsnap
+    when: "{{ not COMMON_SERVER_NO_BACKUPS }}"

--- a/tasks/etckeeper.conf
+++ b/tasks/etckeeper.conf
@@ -1,0 +1,19 @@
+export GIT_AUTHOR_NAME="{{ COMMON_SERVER_ETCKEEPER_COMMIT_USER }}"
+export GIT_AUTHOR_EMAIL="{{ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL }}"
+export GIT_COMMITTER_NAME="{{ COMMON_SERVER_ETCKEEPER_COMMIT_USER }}"
+export GIT_COMMITTER_EMAIL="{{ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL }}"
+
+VCS="git"
+GIT_COMMIT_OPTIONS=""
+
+HIGHLEVEL_PACKAGE_MANAGER=apt
+LOWLEVEL_PACKAGE_MANAGER=dpkg
+
+# Uncomment to avoid committing existing changes once per day.
+#AVOID_DAILY_AUTOCOMMITS=1
+
+# Uncomment to avoid committing existing changes to /etc prior to install.
+# Warning: This will cancel installation so you can commit the changes by hand.
+#AVOID_COMMIT_BEFORE_INSTALL=1
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- hostname: name={{ COMMON_SERVER_HOSTNAME }}
+
+- name: Template hosts
+  template: src=hosts dest=/etc/hosts owner=root group=root mode=0544
+
+- name: install depencencies
+  apt: name={{ item }} state=present
+  with_items: "{{ COMMON_SERVER_DEPENDENCIES }}"
+
+- name: Activate tmpreaper
+  lineinfile: dest=/etc/tmpreaper.conf state=absent regexp="^SHOWWARNING=true"
+
+- name: Configure git author
+  shell: git config --global user.name "{{ COMMON_SERVER_ETCKEEPER_COMMIT_USER }}" && git config --global user.email "{{ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL }}"
+
+- name: etckeeper - Use git
+  copy: src=etckeeper.conf dest=/etc/etckeeper/etckeeper.conf owner=root group=root mode=644 backup=yes
+
+- name: etckeeper - git init && commit
+  shell: etckeeper init && etckeeper commit "Initial commit." creates=/etc/.git
+
+- name: By default allow only ssh
+  ufw: rule=allow port=22 proto=tcp
+
+- name: Set firewall default policy
+  ufw: state=enabled policy=reject

--- a/templates/hosts
+++ b/templates/hosts
@@ -1,0 +1,9 @@
+127.0.0.1 localhost {{ COMMON_SERVER_HOSTNAME }} {{ COMMON_SERVER_HOSTNAME_SHORT }}
+
+# The following lines are desirable for IPv6 capable hosts
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts


### PR DESCRIPTION
A base role for all our deployments (hopefully!), by itself it installs etckeeper and tmpreaper. But mostly it is here to enforce installation of dependant roles: 
-  configure-apt
- geerlingguy.security
- kamaln7.swapfile
- sanity-checker - almost every server has something to monitor, even if this is a disk space on root partition. 
