### PR TITLE
Adds support for floating IP network interface alias

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,11 @@
 COMMON_SERVER_HOSTNAME: "{{ inventory_hostname }}"
 COMMON_SERVER_HOSTNAME_SHORT: "{{ inventory_hostname_short }}"
 
+# Set to create a "floating IP" alias to the primary network interface,
+# for use by external network access and DNS names.
+COMMON_FLOATING_IP: !!null
+COMMON_FLOATING_INTERFACE_NAME: !!null
+
 COMMON_SERVER_ETCKEEPER_COMMIT_USER: "Etc Keeper"
 COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: "ops@example.com"
 

--- a/tasks/floating_ip.yml
+++ b/tasks/floating_ip.yml
@@ -1,0 +1,21 @@
+- name: Add floating IP as network interface alias
+  template:
+    src: network/interfaces.d/floating-ip.cfg
+    dest: /etc/network/interfaces.d/floating-ip.cfg
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Ensure floating alias is included in configuration file
+  lineinfile:
+    dest: /etc/network/interfaces
+    state: present
+    line: "source /etc/network/interfaces.d/*.cfg"
+
+- name: Restart networking service
+  service:
+    name: networking
+    state: restarted
+
+- name: Bring up new interface
+  command: "ifup {{ COMMON_FLOATING_INTERFACE_NAME }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - hostname: name={{ COMMON_SERVER_HOSTNAME }}
 
+- name: Add network interface for floating IP
+  include: floating_ip.yml
+  when: (COMMON_FLOATING_INTERFACE_NAME and COMMON_FLOATING_IP)
+
 - name: Template hosts
   template: src=hosts dest=/etc/hosts owner=root group=root mode=0544
 

--- a/templates/network/interfaces.d/floating-ip.cfg
+++ b/templates/network/interfaces.d/floating-ip.cfg
@@ -1,0 +1,5 @@
+auto {{ COMMON_FLOATING_INTERFACE_NAME }}
+iface {{ COMMON_FLOATING_INTERFACE_NAME }} inet static
+        address {{ COMMON_FLOATING_IP }}
+        netmask 255.255.255.255
+        broadcast {{ COMMON_FLOATING_IP }}


### PR DESCRIPTION
With our dedicated servers, we use a failover IP to allow for quick failover of critical services without having to wait for DNS propagation.

The failover IP address is assigned by OVH/SoYouStart, but must be [added to the server during provisioning](https://www.ovh.com/us/g2043.configure_a_failover_ip_with_ubuntu).

This PR adds two new variables, `COMMON_FAILOVER_IP` and `COMMON_FAILOVER_INTERFACE_NAME`, to construct a new network interface, usually as an alias for the primary.

**Dependencies**

* https://github.com/open-craft/deployment-deploy-services/pull/14 - adds the `network-services` dependency.

**Testing Instructions**

1. Provision a new VM from a Xenial image.
1. Shell into the server and check the current network interfaces: `sudo ifconfig`.  Note the primary interface name, e.g. `ens3`.
1. Clone https://github.com/open-craft/deployment-deploy-services and check out the branch from https://github.com/open-craft/deployment-deploy-services/pull/14, `jill/update-ansible-load-balancer`
1. Edit `requirements.yml` to update the `common-server` stanza to replace `origin/master` with the branch for this PR:

   ```
   - name: common-server
     src: https://github.com/open-craft/ansible-common-server
     version: origin/jill/add-failover-ip
   ```
1. Create a virtualenv and install the `deployment-deploy-services` requirements: 

    ```
    pip install -r requirements.txt
    ansible-galaxy install -r requirements.yml -f
    ```
1. Create small playbook to test this role, e.g. `deploy-failover.yml`:

    ```
    - name: Install Python 2
      hosts: all
      become: true
      gather_facts: false
      tasks:
        - raw: "[ -e /usr/bin/python ] || sudo apt-get update -qq && sudo apt-get install -qq python"

    - name: Set up common servers
      hosts: all
      become: true
      roles:
        - name: common-server
    ```
1. To test the default behaviour, run the test playbook for your VM, e.g. 

   ```
   ansible-playbook --user=ubuntu  -i "<remote IP>," \
      --private-key=@private_key.pem \
      -e "{COMMON_SERVER_NO_BACKUPS: true}" \
      deploy-failover.yml
   ```
1. Shell into your server and ensure that no changes have been made to the server's network interfaces recorded from step 2.
1. Re-run the test playbook with extra variables set to create the failover alias.
    * `COMMON_FAILOVER_IP`: use a failover IP if you have one, or a random IP if you don't.
       If you don't have a real failover, you won't be able to test that the interface actually works, but you should be able to see the alias when it's created.
    * `COMMON_FAILOVER_INTERFACE_NAME`, use your primary network interface name, suffixed with a number to indicate the alias, e.g. "ens3:1"

   ```
   ansible-playbook --user=ubuntu  -i "<remote IP>," \
      --private-key=@private_key.pem \
      -e "{COMMON_SERVER_NO_BACKUPS: true}" \
      -e "{COMMON_FAILOVER_IP: '12.34.56.78'}" \
      -e "{COMMON_FAILOVER_INTERFACE_NAME: 'ens3:1'}" \
      deploy-failover.yml
   ```

**Author notes and concerns**:

1. I didn't like having to roll my own solution to this problem, but the other options weren't better.
   @smarnach [says this is ok](#pullrequestreview-20609031).
   * Tried using an ansible-galaxy module called [`ansible-network-interfaces`](https://github.com/dresden-weekly/ansible-network-interfaces), but that would remove any interface not specified in the configuration.
   * Tried using the [ansible `nmcli` module](http://docs.ansible.com/ansible/nmcli_module.html), but was unable to get the python dependencies to work on xenial, even after installing `python-dbus` and `python-networkinterfaces`.  Error reported: `ImportError: No module named dbus`.
1. Couldn't come up with a clean, automatic way to reliably determine the  `COMMON_FAILOVER_INTERFACE_NAME`.  There's various ugly options, e.g. `ifconfig -a | sed 's/[ \t].*//;/^\(lo\|\)$/d' | head -1`, but they're not reliable or ansible-y.
   @smarnach [says this is ok](#issuecomment-278283123).

**Reviewer**

- [x] @smarnach 