### PR TITLE
Some fixes for the new xenial image on SoYouStart

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,4 @@ COMMON_SERVER_NO_BACKUPS: false
 COMMON_SERVER_DEPENDENCIES:
   - etckeeper
   - tmpreaper
+  - ufw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,4 +34,4 @@
   template: src=timezone dest=/etc/timezone owner=root group=root mode=0644
 
 - name: Set local timezone to UTC
-  file: src=/usr/share/zoneinfo/Etc/UTC dest=/etc/localtime state=link
+  file: src=/usr/share/zoneinfo/Etc/UTC dest=/etc/localtime state=link force=true


### PR DESCRIPTION
The new xenial image of SoYouStart does not come with ufw preinstalled, and `/etc/localtime` is a time instead of a symlink.  These changes was necessary to get the playbook for the reinstallation of `rabbitmq.net.opencraft.hosting` to complete successfully.