### PR TITLE
Add fallback DNS servers.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,8 @@ COMMON_SERVER_DEPENDENCIES:
   - etckeeper
   - tmpreaper
   - ufw
+
+# Use Google public DNS servers as fallback
+COMMON_FALLBACK_DNS_SERVERS:
+  - 8.8.8.8
+  - 8.8.4.4

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart networking
+  service:
+    name: networking
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,13 @@
   include: floating_ip.yml
   when: (COMMON_FLOATING_INTERFACE_NAME and COMMON_FLOATING_IP)
 
+- name: Add fallback DNS servers to /etc/dhcp/dhclient.conf.
+  lineinfile:
+     dest: /etc/dhcp/dhclient.conf
+     regexp: '^\s*append\s+domain-name-servers'
+     line: "append domain-name-servers {{ COMMON_FALLBACK_DNS_SERVERS | join(', ') }};"
+  notify: restart networking
+
 - name: Template hosts
   template: src=hosts dest=/etc/hosts owner=root group=root mode=0544
 


### PR DESCRIPTION
This change adds Google's public DNS servers as fallbacks to the list of DNS servers in `/etc/resolv.conf`.  Our machines typically receive the DNS server by DHCP, so we configure dhclient to add the additional DNS servers to the list it received.

I deployed this change to haproxy-dev, and everything seems to work fine.  For testing, just deploy it to some other low-priority machine (e.g. rabbitmq-dev or stage.console).  Command line (nothing special here, just for easy copy and paste; replace `path_to_key` and `hostname` with appropriate values):

    ansible-playbook -u ubuntu --private-key path_to_key -l hostname -vv deploy-all.yml