### PR TITLE
Install chkrootkit package on all servers.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: "ops@example.com"
 COMMON_SERVER_NO_BACKUPS: false
 
 COMMON_SERVER_DEPENDENCIES:
+  - chkrootkit
   - etckeeper
   - tmpreaper
   - ufw


### PR DESCRIPTION
This package automatically sets up a cron job to run chkrootkit on a daily basis.  The cron job prints any anomalies it detects to stdout, resulting in an email to the ops email address, so installing the package is all we need to do to get notifications if anything is detected.