### PR TITLE
Add cron job to track the security updates of held packages.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,7 @@ COMMON_SERVER_DEPENDENCIES:
   - etckeeper
   - tmpreaper
   - ufw
+  - apt-show-versions
 
 # Use Google public DNS servers as fallback
 COMMON_FALLBACK_DNS_SERVERS:
@@ -61,3 +62,5 @@ COMMON_FALLBACK_DNS_SERVERS:
 # List of chkrootkit disabled tests.
 CHKROOTKIT_DISABLED_TESTS:
   - chkutmp
+
+SECURITY_UPDATE_SCRIPT_LOCATION: "/usr/local/sbin/security_updates_checker.sh"

--- a/files/security_updates_checker.sh
+++ b/files/security_updates_checker.sh
@@ -1,0 +1,10 @@
+set -eo pipefail
+
+SECURITY_UPGRADES=$(apt-show-versions | grep upgradeable | grep security | awk -F':' '{print $1}')
+HELD_SECURITY_UPGRADES=$(sort <(echo "$SECURITY_UPGRADES") <(apt-mark showhold) | uniq -d)
+
+if [ ! -z "$HELD_SECURITY_UPGRADES" ]; then
+    EXTERNAL_ADDRESS=$(ip route get 8.8.8.8 | awk '{print $NF; exit}')
+    echo "Warning: The following packages on host $EXTERNAL_ADDRESS are held packages (and thus can not be upgraded automatically), but also have security upgrades available(!):"
+    echo "$HELD_SECURITY_UPGRADES"
+fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,3 +45,18 @@
 
 - name: Set local timezone to UTC
   file: src=/usr/share/zoneinfo/Etc/UTC dest=/etc/localtime state=link force=true
+
+- name: Copy security update check script
+  copy:
+    src: security_updates_checker.sh
+    dest: "{{ SECURITY_UPDATE_SCRIPT_LOCATION }}"
+    owner: root
+    group: root
+    mode: 0500
+
+- name: Schedule cron job to track security updates of held packages
+  cron:
+    name: "Track security updates"
+    minute: "0"
+    hour: "1"
+    job: "bash {{ SECURITY_UPDATE_SCRIPT_LOCATION }}"


### PR DESCRIPTION
This PR adds a cron job to track security updates of the held packages once a day and notify ops if there are any.

**JIRA tickets**: [OC-3385](https://tasks.opencraft.com/browse/OC-3385)

**Dependencies**: None

**Screenshots**: n/a

**Sandbox URL**: n/a

**Merge deadline**: None

**Testing instructions**:
1. Check the ops ML and see the e-mail sent from postgres stage about security updates for:
`
libruby1.9.1
ruby1.9.1
`

**Reviewers**
- [ ] @bdero 

Squashed from b0a312ab5d8b47d4e23842b6a49aeebdadbf28bf.
Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>