### PR TITLE
Disable swapfile role for dedicated servers

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ dependencies:
   - name: geerlingguy.security
   - name: sanity-checker
   - name: kamaln7.swapfile
+    when: dedicated_server is undefined or not dedicated_server
   # Will fail provisioning if settings not set in vars file.
   - name: backup-to-tarsnap
     when: "{{ not COMMON_SERVER_NO_BACKUPS }}"


### PR DESCRIPTION
When deploying to dedicated servers, disable the creation of a swapfile. 

**Dependencies**: https://github.com/open-craft/ansible-playbooks/pull/5

**Testing instructions**:
Testing this pull request requires setting up an unused server and running the dedicated server playbook on it. After running the playbook there should not be any swapfile set up on the server. 

**Reviewers**
- [ ] @smarnach 